### PR TITLE
Restore OTA binaries in jb.sh

### DIFF
--- a/winter_break/jb.sh
+++ b/winter_break/jb.sh
@@ -131,8 +131,15 @@ install_touch_update_key_squash()
 mntroot rw
 
 # Check if OTA is disabled and if so enable it so hotfix can later be applied
-[ -f "/usr/bin/otaupd.bck" ] && mv /usr/bin/otaupd.bck /usr/bin/otaupd && wb_log "otaupd restored"
-[ -f "/usr/bin/otav3.bck" ] && mv /usr/bin/otav3.bck /usr/bin/otav3 && wb_log "otav3 restored" && wb_log ""
+if [ -f "/usr/bin/otaupd.bck" ] ; then
+  mv /usr/bin/otaupd.bck /usr/bin/otaupd
+  wb_log "otaupd restored"
+fi
+
+if [ -f "/usr/bin/otav3.bck" ] ; then
+  mv /usr/bin/otav3.bck /usr/bin/otav3
+  wb_log "otav3 restored"
+fi
 
 # Check if we need to do something with the OTA pubkey
 if [ ! -f "/etc/uks.sqsh" ] && [ ! -f "/etc/uks/pubdevkey01.pem" ] ; then

--- a/winter_break/jb.sh
+++ b/winter_break/jb.sh
@@ -130,6 +130,10 @@ install_touch_update_key_squash()
 # The real fun starts here
 mntroot rw
 
+# Check if OTA is disabled and if so enable it so hotfix can later be applied
+[ -f "/usr/bin/otaupd.bck" ] && mv /usr/bin/otaupd.bck /usr/bin/otaupd && wb_log "otaupd restored"
+[ -f "/usr/bin/otav3.bck" ] && mv /usr/bin/otav3.bck /usr/bin/otav3 && wb_log "otav3 restored" && wb_log ""
+
 # Check if we need to do something with the OTA pubkey
 if [ ! -f "/etc/uks.sqsh" ] && [ ! -f "/etc/uks/pubdevkey01.pem" ] ; then
   install_touch_update_key
@@ -184,5 +188,11 @@ fi
 # Bye
 mntroot ro
 
-wb_log "Finished installing jailbreak!"
-wb_log "Please install hotfix now."
+wb_log "                                      "
+wb_log "**************************************"
+wb_log "*** Finished installing jailbreak! ***"
+wb_log "***                                ***"
+wb_log "***   Please Install HOTFIX now    ***"
+wb_log "**************************************"
+wb_log "                                      "
+wb_log "                                      "


### PR DESCRIPTION
Added test for ota update files, to circumvent privilege issues when resetting to factory standards with OTA Disable on an already jailbroken unit, which renders a broken installation. Now user can start from scratch by simply installing WinterBreak on a factory reset unit without having to install MRPI+KUAL+renameotabin just to enable OTA updates.

Embellished the final wb_log so it is more visually apparent to user that WinterBreak installation was successful :))