### PR TITLE
Fix case-sensitive link to Mesquito docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![forthebadge](https://forthebadge.com/images/badges/made-with-javascript.svg)](https://forthebadge.com)
 
-WinterBreak is a Kindle jailbreak utilising [Mesquito](https://kindlemodding.github.io/Mesquito/)
+WinterBreak is a Kindle jailbreak utilising [Mesquito](https://kindlemodding.github.io/mesquito/)
 
 
 ## Usage Instructions


### PR DESCRIPTION
Self-explanatory. Redirects to 404 with /Mesquito as the real path is /mesquito. Probably didn't really need a PR. :)
